### PR TITLE
chore(ci): bump k9/a2ml validate-action pins to current main

### DIFF
--- a/.github/workflows/dogfood-gate.yml
+++ b/.github/workflows/dogfood-gate.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Validate A2ML manifests
         if: steps.detect.outputs.count > 0
-        uses: hyperpolymath/a2ml-validate-action@b2f28c39491c0d1ff131b8fb9e197bfea79e411e # main
+        uses: hyperpolymath/a2ml-validate-action@86c6da6d2e9c8c07adaff2737ca7d4b5f7d793af # main
         with:
           path: '.'
           strict: 'false'
@@ -86,7 +86,7 @@ jobs:
 
       - name: Validate K9 contracts
         if: steps.detect.outputs.k9_count > 0
-        uses: hyperpolymath/k9-validate-action@f985acb62d1ed46a4b3434dc6cb148dad95cf62d # main
+        uses: hyperpolymath/k9-validate-action@cfa7f92f6bed88e706a481f7f520e4580d7b9599 # main
         with:
           path: '.'
           strict: 'false'


### PR DESCRIPTION
Stale SHA-pins carried two fixed validator false-positives (k9 pedigree brace bug #7; a2ml identity check on typed/\*file manifests #8/#9). Bumps both to current main and adds github-actions to dependabot to prevent recurrence. Mechanical estate-wide sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)